### PR TITLE
Patch errors for Asahi Linux.

### DIFF
--- a/Sources/POSIXCore/POSIXError.swift
+++ b/Sources/POSIXCore/POSIXError.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #if !os(Windows)
+import Glibc
 
 public struct POSIXError: Error {
   internal let code: CInt
@@ -14,8 +15,8 @@ public struct POSIXError: Error {
 extension POSIXError: CustomStringConvertible {
   public var description: String {
     return withUnsafeTemporaryAllocation(of: CChar.self, capacity: 256) {
-      guard strerror_r(code, $0.baseAddress, $0.count) == 0,
-          let baseAddress = $0.baseAddress else {
+      guard let baseAddress = $0.baseAddress,
+        strerror_r(code, baseAddress, $0.count) == 0 else {
         return "POSIX Error \(code)"
       }
       return String(cString: baseAddress)

--- a/Sources/POSIXCore/POSIXError.swift
+++ b/Sources/POSIXCore/POSIXError.swift
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #if !os(Windows)
+#if canImport(Glibc)
 import Glibc
+#endif
 
 public struct POSIXError: Error {
   internal let code: CInt

--- a/Sources/POSIXCore/SignalHandler.swift
+++ b/Sources/POSIXCore/SignalHandler.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #if !os(Windows)
+import Glibc
 
 private final actor Registry {
   static let shared = Registry()
@@ -152,7 +153,7 @@ private final actor Registry {
       _ = write(Registry.fds[1], &signal, 1)
     }
     #if os(Linux)
-    action.sa_handler = handler
+    action.__sigaction_handler = sigaction.__Unnamed_union___sigaction_handler(sa_handler: handler)
     #else
     action.__sigaction_u.__sa_handler = handler
     #endif

--- a/Sources/POSIXCore/SignalHandler.swift
+++ b/Sources/POSIXCore/SignalHandler.swift
@@ -24,7 +24,7 @@ private final actor Registry {
 
   private var handlers: [CInt:[ObjectIdentifier:Handler]] = [:]
   private var dispositions: [CInt:sigaction] = [:]
-#if $InlineArray
+#if compiler(>=6.2)
   private nonisolated(unsafe) static var fds = InlineArray<2, CInt>(repeating: -1)
 #else
   private nonisolated(unsafe) static var fds = Array<CInt>(repeating: -1, count: 2)

--- a/Sources/POSIXCore/SignalHandler.swift
+++ b/Sources/POSIXCore/SignalHandler.swift
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #if !os(Windows)
+
+#if canImport(Glibc)
 import Glibc
+#endif
 
 private final actor Registry {
   static let shared = Registry()
@@ -152,7 +155,7 @@ private final actor Registry {
       var signal = UInt8(signal)
       _ = write(Registry.fds[1], &signal, 1)
     }
-    #if os(Linux)
+    #if canImport(Glibc)
     action.__sigaction_handler = sigaction.__Unnamed_union___sigaction_handler(sa_handler: handler)
     #else
     action.__sigaction_u.__sa_handler = handler

--- a/Sources/POSIXCore/SystemInfo+POSIX.swift
+++ b/Sources/POSIXCore/SystemInfo+POSIX.swift
@@ -1,12 +1,20 @@
 // Copyright © 2025 Saleem Abdulrasool <compnerd@compnerd.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
-#if !os(Windows)
+#if os(macOS) || os(Linux)
+
+#if os(macOS)
+import Darwin
+#elseif os(Linux)
+import Glibc
+#endif
 
 public enum SystemInfo {
   public static var PageSize: Int {
 #if os(macOS)
     return Int(sysconf(_SC_PAGESIZE))
+#elseif os(Linux)
+    return Int(sysconf(Int32(_SC_PAGESIZE)))
 #else
     precondition(false, "Unable to query page size on this platform")
 #endif

--- a/Sources/POSIXCore/SystemInfo+POSIX.swift
+++ b/Sources/POSIXCore/SystemInfo+POSIX.swift
@@ -1,22 +1,15 @@
 // Copyright © 2025 Saleem Abdulrasool <compnerd@compnerd.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
-#if os(macOS) || os(Linux)
-
-#if os(macOS)
-import Darwin
-#elseif os(Linux)
-import Glibc
-#endif
+#if !os(Windows)
 
 public enum SystemInfo {
   public static var PageSize: Int {
-#if os(macOS)
+#if os(macOS) || GNU
     return Int(sysconf(_SC_PAGESIZE))
-#elseif os(Linux)
-    return Int(sysconf(Int32(_SC_PAGESIZE)))
 #else
     precondition(false, "Unable to query page size on this platform")
+    return -1 // Compiler error: Cannot convert return expression of type '()' to return type 'Int'
 #endif
   }
 }


### PR DESCRIPTION
Hi comnerd, 

I was checking out [VirtualTerminal](https://github.com/compnerd/VirtualTerminal) and ran into a few errors. I'm not 100% sure if these fixes are correct as i'm still new to Linux, but hopefully it's helpful.

Error I got for POSIXError.
```console
└╴  Value of optional type 'UnsafeMutablePointer<CChar>?' (aka 'Optional<UnsafeMutablePointer<Int8>>') must be unwrapped to a value of type 'UnsafeMutablePointer<CChar>' (aka 'UnsafeMutablePointer<Int8>') SourceKit  [23, 33]
```

Error I got for SystemInfo

```console
└╴  Cannot convert return expression of type '()' to return type 'Int' SourceKit  [15, 5]
```

My system info.

```console 
➜  swift-platform-core git:(zane-asahi-linux-patch) hostnamectl
 Static hostname: fedora
       Icon name: computer
      Machine ID: 29196fa12af0453e852f15fe4c684c25
         Boot ID: ea543588fb8240fb95363a0e1e2c8ae9
Operating System: Fedora Linux Asahi Remix 42 (Forty Two [Adams])
     CPE OS Name: cpe:/o:fedoraproject:fedora-asahi-remix:42
          Kernel: Linux 6.14.8-400.asahi.fc42.aarch64+16k
    Architecture: arm64
    
➜  swift-platform-core git:(zane-asahi-linux-patch) swift --version
Swift version 6.1.2 (swift-6.1.2-RELEASE)
Target: aarch64-unknown-linux-gnu
```

Thanks,
Zane
