### PR TITLE
POSIXCore: allow building on macOS v15

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,9 @@
 import PackageDescription
 
 let _ = Package(name: "swift-platform-core",
+                platforms: [
+                  .macOS(.v15),
+                ],
                 products: [
                   .library(name: "WindowsCore", targets: ["WindowsCore"]),
                   .library(name: "POSIXCore", targets: ["POSIXCore"]),


### PR DESCRIPTION
`Task.immediate` is preferable to `Task.synchronously`, but is only available on macOS 26 with Swift 6.2. This allows building on macOS allowing testing on stable macOS environments.