### PR TITLE
WindowsCore: add `KEY_READ` type coercion wrapper

### DIFF
--- a/Sources/WindowsCore/WinSDK+Overlay.swift
+++ b/Sources/WindowsCore/WinSDK+Overlay.swift
@@ -166,8 +166,28 @@ public var IDLE_PRIORITY_CLASS: DWORD {
 }
 
 @_transparent
+public var KEY_ENUMERATE_SUB_KEYS: DWORD {
+  DWORD(WinSDK.KEY_ENUMERATE_SUB_KEYS)
+}
+
+@_transparent
 public var KEY_EVENT: WORD {
   WORD(WinSDK.KEY_EVENT)
+}
+
+@_transparent
+public var KEY_NOTIFY: DWORD {
+  DWORD(WinSDK.KEY_NOTIFY)
+}
+
+@_transparent
+public var KEY_QUERY_VALUE: DWORD {
+  DWORD(WinSDK.KEY_QUERY_VALUE)
+}
+
+@_transparent
+public var KEY_READ: DWORD {
+  (STANDARD_RIGHTS_READ | KEY_QUERY_VALUE | KEY_ENUMERATE_SUB_KEYS | KEY_NOTIFY) & ~SYNCHRONIZE
 }
 
 @_transparent
@@ -278,6 +298,11 @@ public var STANDARD_RIGHTS_READ: DWORD {
 @_transparent
 public var SUBLANG_DEFAULT: WORD {
   WORD(WinSDK.SUBLANG_DEFAULT)
+}
+
+@_transparent
+public var SYNCHRONIZE: DWORD {
+  DWORD(WinSDK.SYNCHRONIZE)
 }
 
 @_transparent


### PR DESCRIPTION
Add a type conversion helper for `KEY_READ` as the macro cannot be directly imported via the ClangImporter.