### PR TITLE
WindowsCore: remove Foundation dependency

### DIFF
--- a/Sources/WindowsCore/NTAPI.swift
+++ b/Sources/WindowsCore/NTAPI.swift
@@ -4,10 +4,10 @@
 #if os(Windows)
 
 import WinSDK
-import Foundation
+import FoundationEssentials
 
 internal var hNTDLL: HMODULE? {
-  "ntdll.dll".withCString(encodedAs: UTF16.self, GetModuleHandleW)
+  "ntdll.dll".withUTF16CString(GetModuleHandleW)
 }
 
 public typealias NtQueryInformationProcessTy =

--- a/Sources/WindowsCore/String+Extensions.swift
+++ b/Sources/WindowsCore/String+Extensions.swift
@@ -1,0 +1,32 @@
+// Copyright © 2025 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+import WinSDK
+
+extension String {
+  /// Calls the given closure with a pointer to the contents of the string,
+  /// represented as a null-terminated UTF-16 encoded C string.
+  ///
+  /// This uses temporary stack allocation when possible, avoiding heap
+  /// allocation for reasonably-sized strings.
+  ///
+  /// - Parameter body: A closure with a pointer parameter that points to a
+  ///   null-terminated UTF-16 string. If `body` has a return value, that value
+  ///   is also used as the return value for this method.
+  /// - Returns: The return value, if any, of the `body` closure parameter.
+  public func withUTF16CString<R>(_ body: (UnsafePointer<WCHAR>?) throws -> R) rethrows -> R {
+    let count = self.utf16.count
+    return try withUnsafeTemporaryAllocation(of: WCHAR.self, capacity: count + 1) { pBuffer in
+      if self.utf16.withContiguousStorageIfAvailable({ pSourceBuffer in
+        pSourceBuffer.baseAddress?.withMemoryRebound(to: WCHAR.self, capacity: count) { pSource in
+          pBuffer.baseAddress?.initialize(from: pSource, count: count)
+        }
+      }) == nil {
+        _ = pBuffer.initialize(from: self.utf16)
+      }
+
+      pBuffer[count] = 0 // null terminator
+      return try body(pBuffer.baseAddress)
+    }
+  }
+}


### PR DESCRIPTION
Remove the Foundation dependency as we used it for a single purpose: to convert to a UTF16 string representation for use on Windows. Introduce a `withUTF16CString` helper that avoids Foundation for the single use.