### PR TITLE
WindowsCore: replace `Foundation with `FoundationEssentials`

### DIFF
--- a/Sources/WindowsCore/NTAPI.swift
+++ b/Sources/WindowsCore/NTAPI.swift
@@ -4,7 +4,7 @@
 #if os(Windows)
 
 import WinSDK
-import Foundation
+import FoundationEssentials
 
 internal var hNTDLL: HMODULE? {
   "ntdll.dll".withCString(encodedAs: UTF16.self, GetModuleHandleW)


### PR DESCRIPTION
We only use `String.withCString(encodedAs:_:)`, avoid the heavier dependency.