### PR TITLE
POSIXCore: repair a number of issues for Linux

### DIFF
--- a/Sources/POSIXCore/POSIXError.swift
+++ b/Sources/POSIXCore/POSIXError.swift
@@ -14,8 +14,8 @@ public struct POSIXError: Error {
 extension POSIXError: CustomStringConvertible {
   public var description: String {
     return withUnsafeTemporaryAllocation(of: CChar.self, capacity: 256) {
-      guard strerror_r(code, $0.baseAddress, $0.count) == 0,
-          let baseAddress = $0.baseAddress else {
+      guard let baseAddress = $0.baseAddress,
+          strerror_r(code, baseAddress, $0.count) == 0 else {
         return "POSIX Error \(code)"
       }
       return String(cString: baseAddress)

--- a/Sources/POSIXCore/SignalHandler.swift
+++ b/Sources/POSIXCore/SignalHandler.swift
@@ -154,7 +154,10 @@ private final actor Registry {
       _ = write(Registry.fds[1], &signal, 1)
     }
     #if os(Linux)
-    action.sa_handler = handler
+    // TODO(compnerd) As per the IEEE 1003.1/1003.1b and X/Open standards, the
+    // GNU C runtime replaced the `sa_handler` member with a macro which expands
+    // to `__sigaction_handler.sa_handler`.
+    action.__sigaction_handler.sa_handler = handler
     #else
     action.__sigaction_u.__sa_handler = handler
     #endif

--- a/Sources/POSIXCore/SystemInfo+POSIX.swift
+++ b/Sources/POSIXCore/SystemInfo+POSIX.swift
@@ -5,11 +5,7 @@
 
 public enum SystemInfo {
   public static var PageSize: Int {
-#if os(macOS)
     return Int(sysconf(_SC_PAGESIZE))
-#else
-    precondition(false, "Unable to query page size on this platform")
-#endif
   }
 }
 


### PR DESCRIPTION
This pull request makes targeted improvements and bug fixes to the POSIX core library, focusing on error handling, signal handler setup, and system information retrieval. The main changes improve portability and correctness, especially for Linux platforms.

**Signal handling and platform compatibility:**
- Updated the signal handler assignment in `SignalHandler.swift` for Linux to use the correct field (`__sigaction_handler.sa_handler`) as required by GNU C and POSIX standards, improving compatibility and correctness.

**Error handling:**
- Fixed the order of operations in the `POSIXError` description to ensure the buffer's base address is valid before calling `strerror_r`, preventing potential crashes.

**System information retrieval:**
- Simplified `SystemInfo.PageSize` by removing platform-specific checks and always using `sysconf(_SC_PAGESIZE)`, assuming all supported platforms provide this call.