### PR TITLE
POSIXCore: add some TIO GNU constant coercion overlay values

### DIFF
--- a/Sources/POSIXCore/GNU+Overlay.swift
+++ b/Sources/POSIXCore/GNU+Overlay.swift
@@ -13,6 +13,31 @@ package var _SC_PAGESIZE: CInt {
   CInt(Glibc._SC_PAGESIZE)
 }
 
+@_transparent
+public var ECHO: tcflag_t {
+  tcflag_t(Glibc.ECHO)
+}
+
+@_transparent
+public var ICANON: tcflag_t {
+  tcflag_t(Glibc.ICANON)
+}
+
+@_transparent
+public var ICRNL: tcflag_t {
+  tcflag_t(Glibc.ICRNL)
+}
+
+@_transparent
+public var IXON: tcflag_t {
+  tcflag_t(Glibc.IXON)
+}
+
+@_transparent
+public var TIOCGWINSZ: CUnsignedLong {
+  CUnsignedLong(Glibc.TIOCGWINSZ)
+}
+
 #endif
 
 #endif


### PR DESCRIPTION
Increase coverage of GNU TIO constants to support VirtualTerminal with the GNU C runtime.