### PR TITLE
WindowsCore: add definition for `MAKEWORD`

### DIFF
--- a/Sources/WindowsCore/WinSDK+Overlay.swift
+++ b/Sources/WindowsCore/WinSDK+Overlay.swift
@@ -621,6 +621,11 @@ public func HRESULT_FACILITY(_ hr: HRESULT) -> WORD {
 }
 
 @_transparent
+public func MAKEWORD(_ low: BYTE, _ high: BYTE) -> WORD {
+  return (WORD(high) << 8) | WORD(low) 
+}
+
+@_transparent
 public func MAKELANGID(_ primary: WORD, _ sub: WORD) -> DWORD {
   return DWORD((sub << 10) | primary)
 }


### PR DESCRIPTION
This is a complex function-like macro that concatenates to bytes. The complexity stems in the extensive type-casting. Provide a Swift implementation for this macro.